### PR TITLE
Integrate eslint-plugin-ferns

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+const useEffectComment = require("./rules/use-effect-comment");
+const requireSuperagentExpect = require("./rules/require-superagent-expect");
+
 // eslint-disable-next-line no-undef
 module.exports = {
   parser: "@typescript-eslint/parser",
@@ -328,6 +331,10 @@ module.exports = {
         tabSize: 2,
       },
     ],
+
+    // Custom rules
+    "use-effect-comment": useEffectComment,
+    "require-superagent-expect": requireSuperagentExpect,
   },
 };
 

--- a/rules/require-superagent-expect.js
+++ b/rules/require-superagent-expect.js
@@ -1,0 +1,48 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'ensure every superagent call has an expect call at the end',
+      category: 'Best Practices',
+      recommended: false
+    },
+    fixable: null,
+    schema: [] // no options
+  },
+  create: function(context) {
+    let superagentVariables = new Map() // Track variables assigned from superagent calls
+
+    return {
+      // Capture superagent calls in async/await context
+      AwaitExpression(node) {
+        if (node.argument.type === 'CallExpression' &&
+                    node.argument.callee.type === 'MemberExpression' &&
+                    node.argument.callee.object.name === 'familyMember2Agent') {
+          let parent = node.parent
+          if (parent.type === 'VariableDeclarator' && parent.id.type === 'Identifier') {
+            // Store the variable name
+            superagentVariables.set(parent.id.name, node.argument)
+          }
+        }
+      },
+      // Check each CallExpression for expect usage with stored variables
+      CallExpression(node) {
+        if (node.callee.name === 'expect' && node.arguments.length > 0) {
+          let arg = node.arguments[0]
+          if (arg.type === 'Identifier' && superagentVariables.has(arg.name)) {
+            superagentVariables.delete(arg.name) // Found a matching expect call
+          }
+        }
+      },
+      'Program:exit'() {
+        // At the end of the program, check for any superagent calls without matching expect calls
+        superagentVariables.forEach((value, key) => {
+          context.report({
+            node: value,
+            message: `The superagent call assigned to '${key}' must be followed by an expect call.`
+          })
+        })
+      }
+    }
+  }
+}

--- a/rules/use-effect-comment.js
+++ b/rules/use-effect-comment.js
@@ -1,0 +1,35 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'require a comment above all useEffect hooks',
+      category: 'Best Practices',
+      recommended: false
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: []
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.name === 'useEffect' ||
+                    (node.callee.type === 'MemberExpression' &&
+                        node.callee.property.name === 'useEffect')
+        ) {
+          const sourceCode = context.getSourceCode()
+          const commentsBefore = sourceCode.getCommentsBefore(node)
+
+          // Check if there is at least one comment before the useEffect
+          if (commentsBefore.length === 0) {
+            context.report({
+              node,
+              message: 'Expected a comment above the useEffect hook.'
+            })
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
No reason to have these as two separate packages. I didn't realize you could include custom rules in an eslint-config-* package.